### PR TITLE
Sampling rate in begin is truncated to 0.

### DIFF
--- a/Adafruit_TMP006.cpp
+++ b/Adafruit_TMP006.cpp
@@ -156,7 +156,6 @@ uint16_t Adafruit_TMP006::read16(uint8_t a) {
 #endif
   Wire.endTransmission(); // end transmission
   
-  Wire.beginTransmission(_addr); // start transmission to device 
   Wire.requestFrom(_addr, (uint8_t)2);// send data n-bytes read
 #if (ARDUINO >= 100)
   ret = Wire.read(); // receive DATA
@@ -167,7 +166,6 @@ uint16_t Adafruit_TMP006::read16(uint8_t a) {
   ret <<= 8;
   ret |= Wire.receive(); // receive DATA
 #endif
-  Wire.endTransmission(); // end transmission
 
   return ret;
 }

--- a/Adafruit_TMP006.cpp
+++ b/Adafruit_TMP006.cpp
@@ -25,7 +25,7 @@ Adafruit_TMP006::Adafruit_TMP006(uint8_t i2caddr) {
 }
 
 
-boolean Adafruit_TMP006::begin(uint8_t samplerate) {
+boolean Adafruit_TMP006::begin(uint16_t samplerate) {
   Wire.begin();
 
   write16(TMP006_CONFIG, TMP006_CFG_MODEON | TMP006_CFG_DRDYEN | samplerate);

--- a/Adafruit_TMP006.h
+++ b/Adafruit_TMP006.h
@@ -62,7 +62,7 @@
 class Adafruit_TMP006  {
  public:
   Adafruit_TMP006(uint8_t addr = TMP006_I2CADDR);
-  boolean begin(uint8_t samplerate = TMP006_CFG_16SAMPLE);  // by default go highres
+  boolean begin(uint16_t samplerate = TMP006_CFG_16SAMPLE);  // by default go highres
 
   void sleep();  // Put chip into low power mode (disables temperature measurements).
   void wake();   // Wake from low power mode.


### PR DESCRIPTION
begin() takes a uint8_t but the samplerate is 16bit.
Hence the sample rate gets truncated to 0.
