### PR TITLE
Add SDA and SCL pin option

### DIFF
--- a/Adafruit_TMP006.cpp
+++ b/Adafruit_TMP006.cpp
@@ -29,13 +29,22 @@ Adafruit_TMP006::Adafruit_TMP006(uint8_t i2caddr) { _addr = i2caddr; }
 
 /**************************************************************************/
 /*!
-    @brief Initialize I2C and connect to the TMP006 sensor
+    @brief Initialize I2C and connect to the TMP006 sensor. For ESP board family you can modify the SDA and SCL PIN
+    @param sdaPin The SDA pin to use or use default
+    @param sdaPin The SCL pin to use or use default
     @param samplerate The value written to TMP006_CONFIG
     @returns True if sensor found
 */
 /**************************************************************************/
-boolean Adafruit_TMP006::begin(uint16_t samplerate) {
-  Wire.begin();
+boolean Adafruit_TMP006::begin(int sdaPin, int sclPin, uint16_t samplerate) {
+  #if defined(__AVR__)
+    Wire.begin();
+  #else
+    if(sdaPin != -1 && sclPin != -1)
+      Wire.begin(sdaPin, sclPin);
+    else 
+      Wire.begin();
+  #endif
 
   write16(TMP006_CONFIG, TMP006_CFG_MODEON | TMP006_CFG_DRDYEN | samplerate);
 

--- a/Adafruit_TMP006.h
+++ b/Adafruit_TMP006.h
@@ -68,7 +68,7 @@ class Adafruit_TMP006 {
 public:
   Adafruit_TMP006(uint8_t addr = TMP006_I2CADDR);
   boolean
-  begin(uint16_t samplerate = TMP006_CFG_16SAMPLE); // by default go highres
+  begin(int sdaPin = -1, int sclPin = -1, uint16_t samplerate = TMP006_CFG_16SAMPLE); // by default go highres
 
   void
   sleep(); // Put chip into low power mode (disables temperature measurements).


### PR DESCRIPTION
## Description

Modify begin function with SDA and SCL params so user can modify it when it's used with ESP Board family. I'm already add macros check where the code compiled on.

## Testing

This modification already tested and running well on Lolin32 Lite (ESP32 Family), Compiled successfully on AVR and ESP8266 Board Family.